### PR TITLE
Adding filter arguments to relay URLs

### DIFF
--- a/src/js/Nostr.ts
+++ b/src/js/Nostr.ts
@@ -194,7 +194,7 @@ export default {
     const relay = relayInit(url, this.eventsById);
     relay.on('connect', () => {
       for (const [name, filters] of this.subscribedFiltersByName.entries()) {
-        const sub = relay.sub(filters, {});
+        const sub = relay.sub(filters, {}, relay.filters);
         if (!this.subscriptionsByName.has(name)) {
           this.subscriptionsByName.set(name, new Set());
         }
@@ -378,7 +378,7 @@ export default {
     }
 
     for (const relay of this.relays.values()) {
-      const sub = relay.sub(filters, {});
+      const sub = relay.sub(filters, {}, relay.filters);
       // TODO update relay lastSeen
       sub.on('event', (event) => this.handleEvent(event));
       if (once) {


### PR DESCRIPTION
Added ability to pass parameters to relays via their url, in the format:  wss://relay.io?a=12345

This will enforce the tag filter on all queries to that relay, allowing users to subscribe to only a subset of the events on a server, depending on their needs.